### PR TITLE
fix: wallet account changes

### DIFF
--- a/src/web/static/js/walletManager.js
+++ b/src/web/static/js/walletManager.js
@@ -765,7 +765,7 @@ function updateWalletCard() {
                     <span class="text-gray-300">${recommendingModels.join(', ')}</span>
                 </div>
                 ` : ''}
-                ${swapAmount > 0 && ethPrice > 0 ? `
+                ${swapAmount > 0 && (recommendedAction === 'BUY' || (recommendedAction === 'SELL' && ethPrice > 0)) ? `
                 <div class="flex items-center">
                     <span class="text-gray-400 w-40">Suggested Swap:</span>
                     <span class="text-gray-300" data-suggested-swap="${recommendedAction === 'BUY' ? `~$${swapAmount.toFixed(2)} ${swapDirection}` : `~${(swapAmount / ethPrice).toFixed(4)} ${swapDirection}`}">


### PR DESCRIPTION
This PR addresses wallet account inconsistencies by ensuring that SELL notifications only compute when a valid ETH price is available. Key changes include using a safety check for ETH prices, updating the computation of SELL amounts from currentPrice to ethPrice, and adding a notification warning during test events when ETH price data is unavailable.