### PR TITLE
Fix: fear-greed and wallet notifications values

### DIFF
--- a/src/tools/fear_greed_api.py
+++ b/src/tools/fear_greed_api.py
@@ -19,7 +19,7 @@ class FearGreedClient:
         self.base_url = "https://api.alternative.me/fng/"
         self.session = requests.Session()
         self._cache = {"timestamp": 0, "data": None}
-        self.cache_duration = int(time.time())
+        self.cache_duration = 12 * 3600  # Cache for 12 hours
 
     def get_fear_greed_index(self) -> Dict[str, str]:
         """
@@ -68,31 +68,4 @@ class FearGreedClient:
             return {
                 "fear_greed_value": "50",  # Neutral value
                 "fear_greed_sentiment": "neutral"
-            }
-
-    def get_index(self) -> Dict[str, str]:
-        """
-        Get current Fear & Greed Index value and classification.
-
-        Returns:
-            Dictionary containing value and value_classification
-        """
-        try:
-            response = self.session.get(f"{self.base_url}?limit=1")
-            response.raise_for_status()
-            data = response.json()
-
-            if "data" not in data or not data["data"]:
-                raise ValueError("Invalid response from Fear & Greed API")
-
-            return {
-                "value": data["data"][0]["value"],
-                "value_classification": data["data"][0]["value_classification"]
-            }
-
-        except Exception as e:
-            print(f"Error fetching Fear & Greed Index: {str(e)}")
-            return {
-                "value": "50",  # Neutral value
-                "value_classification": "Neutral"
             }

--- a/src/web/static/js/modelPredictions.js
+++ b/src/web/static/js/modelPredictions.js
@@ -137,11 +137,17 @@ function updateModelDecisions(data, walletAddress) {
                 // Show browser notification for BUY and SELL signals only
                 showNotification(message, 'info');
 
+                // Log the notification being sent for debugging
+                console.log(`LLM CONSENSUS: ${consensus} signal detected from ${Object.keys(validDecisions).length} models`);
+                console.log(`Sending notification with message: "${message}"`);
+                console.log(`WALLET ADDRESS: ${walletAddress}, ENABLE_RECOMMENDATIONS: ${window.enableSwapRecommendations}`);
+
                 // Force wallet balance refresh with a slight delay
                 // This ensures the wallet card recommendation is updated first
                 setTimeout(() => {
                     getWalletBalances().then(() => {
                         // Send wallet notification after balances are refreshed - only for BUY and SELL
+                        console.log(`Calling sendWalletNotification(${consensus}, "${message}")`);
                         sendWalletNotification(consensus, message);
                     });
                 }, 500);

--- a/src/web/static/js/notificationManager.js
+++ b/src/web/static/js/notificationManager.js
@@ -128,7 +128,7 @@ async function sendWalletNotification(signalType, message) {
                         console.log(`BUY calculation: $${swapAmount.toFixed(2)} / $${currentPrice} = ${ethAmount} ETH (after rounding)`);
                         
                         // Validate the ETH amount format is valid for toWei
-                        const ethAmountString = ethAmount.toString();
+                        let ethAmountString = ethAmount.toString();
                         if (!/^\d*\.?\d*$/.test(ethAmountString) || isNaN(ethAmount) || !isFinite(ethAmount)) {
                             console.log(`Invalid ETH amount calculated: ${ethAmountString}. Using fallback.`);
                             ethAmount = 0;
@@ -272,7 +272,7 @@ async function sendWalletNotification(signalType, message) {
                             // For BUY notifications, we're simulating a token swap
                             // Since we can't actually send USDC in a native transaction,
                             // we'll create a "representative" transaction with the ETH equivalent
-                            const ethAmountString = ethAmount.toString();
+                            let ethAmountString = ethAmount.toString();
                             console.log(`BUY DEBUG - ethAmount: ${ethAmount}, ethAmountString: "${ethAmountString}"`);
                             
                             // Ensure the value is valid for toWei
@@ -339,7 +339,7 @@ async function sendWalletNotification(signalType, message) {
                     // This gives a more realistic preview of what would be sent
                     if (ethAmount > 0) {
                         try {
-                            const ethAmountString = ethAmount.toString();
+                            let ethAmountString = ethAmount.toString();
                             // Ensure the value is valid for toWei
                             if (!/^\d*\.?\d*$/.test(ethAmountString)) {
                                 throw new Error("Invalid ETH amount format");

--- a/src/web/static/js/notificationManager.js
+++ b/src/web/static/js/notificationManager.js
@@ -1,5 +1,9 @@
 // Notification management functions for Simple Crypto Trading Bot Chef
 
+// Initialize global variables
+window.llmSellAdditionalData = null;
+window.llmBuyAdditionalData = null;
+
 /**
  * Request permission to send browser notifications
  * @returns {Promise<string>} - Promise resolving to the permission state
@@ -76,53 +80,120 @@ async function sendWalletNotification(signalType, message) {
         let ethAmount = 0;
         
         if (signalType === 'BUY') {
-            // Extract the USD amount from the message string (e.g., "Suggested Swap: ~$1.42 USDC → ETH")
-            const usdMatch = message.match(/~\$([0-9.]+)/);
-            if (usdMatch && usdMatch[1]) {
-                swapAmount = parseFloat(usdMatch[1]);
-                // Make sure currentPrice is valid before dividing
-                if (currentPrice > 0) {
-                    // Calculate the ETH equivalent for the transaction using the currentPrice from wallet balances
-                    // This calculates how much ETH the user would receive when swapping USDC
-                    ethAmount = swapAmount / currentPrice;
+            // First check for the LLM signal format: "BUY Signal at $2085.28"
+            const llmSignalMatch = message.match(/BUY Signal at \$([0-9.]+)/);
+            
+            if (llmSignalMatch && llmSignalMatch[1]) {
+                // LLM signal format - extract the price directly
+                const price = parseFloat(llmSignalMatch[1]);
+                if (!isNaN(price) && price > 0) {
+                    // Extract which models recommended this trade
+                    const recommendedBy = message.match(/Recommended by: (.*)/);
+                    const modelsText = recommendedBy ? recommendedBy[1] : "AI models";
                     
-                    // Make sure we have a reasonable value that's not subject to floating point errors
-                    ethAmount = parseFloat(ethAmount.toFixed(8));
-                    console.log(`BUY calculation: $${swapAmount.toFixed(2)} / $${currentPrice} = ${ethAmount} ETH (after rounding)`);
-                    
-                    // Validate the ETH amount format is valid for toWei
-                    const ethAmountString = ethAmount.toString();
-                    if (!/^\d*\.?\d*$/.test(ethAmountString) || isNaN(ethAmount) || !isFinite(ethAmount)) {
-                        console.log(`Invalid ETH amount calculated: ${ethAmountString}. Using fallback.`);
-                        ethAmount = 0;
+                    // Since this is an LLM signal, we'll calculate a reasonable swap amount
+                    // Using a standard small amount like $10 for notifications
+                    swapAmount = 10.0;
+                    if (currentPrice > 0) {
+                        ethAmount = swapAmount / currentPrice;
+                        ethAmount = parseFloat(ethAmount.toFixed(8));
+                        console.log(`LLM BUY Signal: Using standard $${swapAmount.toFixed(2)} USDC = ${ethAmount.toFixed(6)} ETH at price $${currentPrice}`);
+                        
+                        // Set additional data for the transaction
+                        message = `BUY Signal at $${currentPrice}\nRecommended by: ${modelsText}`;
+                        
+                        // Prepare the additional data for the transaction
+                        const llmBuyAdditionalData = ` [LLM TRADING SIGNAL - ${modelsText} recommend buying ETH at $${currentPrice}. This would swap $${swapAmount.toFixed(2)} USDC for ~${ethAmount.toFixed(6)} ETH]`;
+                        
+                        // Store this for use in the transaction params later
+                        window.llmBuyAdditionalData = llmBuyAdditionalData;
                     } else {
-                        console.log(`Parsed BUY: $${swapAmount.toFixed(2)} USDC = ${ethAmount.toFixed(6)} ETH at price $${currentPrice}`);
+                        console.log(`LLM BUY Signal: Cannot calculate ETH amount: currentPrice is invalid`);
+                        ethAmount = 0;
                     }
-                } else {
-                    console.log(`Cannot calculate ETH amount: currentPrice (${currentPrice}) is invalid`);
-                    ethAmount = 0;
+                }
+            } else {
+                // Original "Suggested Swap" format: "Suggested Swap: ~$1.42 USDC → ETH"
+                const usdMatch = message.match(/~\$([0-9.]+)/);
+                if (usdMatch && usdMatch[1]) {
+                    swapAmount = parseFloat(usdMatch[1]);
+                    // Make sure currentPrice is valid before dividing
+                    if (currentPrice > 0) {
+                        // Calculate the ETH equivalent for the transaction using the currentPrice from wallet balances
+                        // This calculates how much ETH the user would receive when swapping USDC
+                        ethAmount = swapAmount / currentPrice;
+                        
+                        // Make sure we have a reasonable value that's not subject to floating point errors
+                        ethAmount = parseFloat(ethAmount.toFixed(8));
+                        console.log(`BUY calculation: $${swapAmount.toFixed(2)} / $${currentPrice} = ${ethAmount} ETH (after rounding)`);
+                        
+                        // Validate the ETH amount format is valid for toWei
+                        const ethAmountString = ethAmount.toString();
+                        if (!/^\d*\.?\d*$/.test(ethAmountString) || isNaN(ethAmount) || !isFinite(ethAmount)) {
+                            console.log(`Invalid ETH amount calculated: ${ethAmountString}. Using fallback.`);
+                            ethAmount = 0;
+                        } else {
+                            console.log(`Parsed BUY: $${swapAmount.toFixed(2)} USDC = ${ethAmount.toFixed(6)} ETH at price $${currentPrice}`);
+                        }
+                    } else {
+                        console.log(`Cannot calculate ETH amount: currentPrice (${currentPrice}) is invalid`);
+                        ethAmount = 0;
+                    }
                 }
             }
         } else if (signalType === 'SELL') {
-            // Extract the ETH amount from the message string (e.g., "Suggested Swap: ~0.0123 ETH → $25.67 USDC")
-            const ethMatch = message.match(/~([0-9.]+) ETH/);
-            if (ethMatch && ethMatch[1]) {
-                // Validate the ETH amount format is valid before parsing
-                const rawEthAmount = ethMatch[1];
-                if (!/^\d*\.?\d*$/.test(rawEthAmount) || isNaN(parseFloat(rawEthAmount)) || !isFinite(parseFloat(rawEthAmount))) {
-                    console.log(`Invalid ETH amount format in message: ${rawEthAmount}. Using fallback.`);
-                    ethAmount = 0;
-                } else {
-                    ethAmount = parseFloat(rawEthAmount);
+            // First check for the LLM signal format: "SELL Signal at $2085.28"
+            const llmSignalMatch = message.match(/SELL Signal at \$([0-9.]+)/);
+            
+            if (llmSignalMatch && llmSignalMatch[1]) {
+                // LLM signal format - extract the price directly
+                const price = parseFloat(llmSignalMatch[1]);
+                if (!isNaN(price) && price > 0) {
+                    // Extract which models recommended this trade
+                    const recommendedBy = message.match(/Recommended by: (.*)/);
+                    const modelsText = recommendedBy ? recommendedBy[1] : "AI models";
                     
-                    // Make sure currentPrice is valid before multiplying
+                    // Since this is an LLM signal, we'll calculate a reasonable ETH amount
+                    // Using a standard small amount like 0.005 ETH for notifications
+                    ethAmount = 0.005;
                     if (currentPrice > 0) {
-                        // Calculate USD equivalent using the currentPrice from wallet balances
                         swapAmount = ethAmount * currentPrice;
-                        console.log(`Parsed SELL: ${ethAmount.toFixed(6)} ETH = $${swapAmount.toFixed(2)} USDC at price $${currentPrice}`);
+                        console.log(`LLM SELL Signal: Using standard ${ethAmount.toFixed(6)} ETH = $${swapAmount.toFixed(2)} USDC at price $${currentPrice}`);
+                        
+                        // Set additional data for the transaction
+                        message = `SELL Signal at $${currentPrice}\nRecommended by: ${modelsText}`;
+                        
+                        // Prepare the additional data for the transaction
+                        const llmAdditionalData = ` [LLM TRADING SIGNAL - ${modelsText} recommend selling ETH at $${currentPrice}. This would swap ${ethAmount.toFixed(6)} ETH for ~$${swapAmount.toFixed(2)} USDC]`;
+                        
+                        // Store this for use in the transaction params later
+                        window.llmSellAdditionalData = llmAdditionalData;
                     } else {
-                        console.log(`Cannot calculate USD amount: currentPrice (${currentPrice}) is invalid`);
+                        console.log(`LLM SELL Signal: Cannot calculate USDC amount: currentPrice is invalid`);
                         swapAmount = 0;
+                    }
+                }
+            } else {
+                // Original "Suggested Swap" format: "Suggested Swap: ~0.0123 ETH → $25.67 USDC"
+                const ethMatch = message.match(/~([0-9.]+) ETH/);
+                if (ethMatch && ethMatch[1]) {
+                    // Validate the ETH amount format is valid before parsing
+                    const rawEthAmount = ethMatch[1];
+                    if (!/^\d*\.?\d*$/.test(rawEthAmount) || isNaN(parseFloat(rawEthAmount)) || !isFinite(parseFloat(rawEthAmount))) {
+                        console.log(`Invalid ETH amount format in message: ${rawEthAmount}. Using fallback.`);
+                        ethAmount = 0;
+                    } else {
+                        ethAmount = parseFloat(rawEthAmount);
+                        
+                        // Make sure currentPrice is valid before multiplying
+                        if (currentPrice > 0) {
+                            // Calculate USD equivalent using the currentPrice from wallet balances
+                            swapAmount = ethAmount * currentPrice;
+                            console.log(`Parsed SELL: ${ethAmount.toFixed(6)} ETH = $${swapAmount.toFixed(2)} USDC at price $${currentPrice}`);
+                        } else {
+                            console.log(`Cannot calculate USD amount: currentPrice (${currentPrice}) is invalid`);
+                            swapAmount = 0;
+                        }
                     }
                 }
             }
@@ -231,9 +302,13 @@ async function sendWalletNotification(signalType, message) {
                             
                             console.log(`Using equivalent ETH amount for BUY notification: ${ethAmountString} ETH (USDC value: $${swapAmount.toFixed(2)})`);
                             
-                            // Update data to show it's a test transaction representing a BUY
-                            const additionalData = ` [THIS IS A TEST - Would swap $${swapAmount.toFixed(2)} USDC to receive ~${ethAmount.toFixed(6)} ETH]`;
+                            // Update data to show it's a test transaction representing a BUY from LLM signals
+                            const additionalData = window.llmBuyAdditionalData || 
+                                ` [THIS IS A TEST - Would swap $${swapAmount.toFixed(2)} USDC to receive ~${ethAmount.toFixed(6)} ETH]`;
                             txParams.data = window.web3.utils.toHex(message + additionalData);
+                            
+                            // Clear the stored data after use
+                            window.llmBuyAdditionalData = null;
                         } catch (valueError) {
                             console.error("Error setting ETH value for BUY:", valueError);
                             // Try to create a reasonable fallback based on the current price
@@ -281,8 +356,12 @@ async function sendWalletNotification(signalType, message) {
                             console.log(`Using actual ETH amount for SELL notification: ${ethAmountString} ETH`);
                             
                             // Update data to show it's a test transaction
-                            const additionalData = ` [THIS IS A TEST - Would swap ${ethAmount.toFixed(6)} ETH to receive ~$${swapAmount.toFixed(2)} USDC]`;
+                            const additionalData = window.llmSellAdditionalData || 
+                                ` [THIS IS A TEST - Would swap ${ethAmount.toFixed(6)} ETH to receive ~$${swapAmount.toFixed(2)} USDC]`;
                             txParams.data = window.web3.utils.toHex(message + additionalData);
+                            
+                            // Clear the stored data after use
+                            window.llmSellAdditionalData = null;
                         } catch (valueError) {
                             console.error("Error setting ETH value:", valueError);
                             // Try to create a reasonable fallback based on the current price


### PR DESCRIPTION
This PR fixes issues related to fear-greed caching as well as wallet notification values for both BUY and SELL signals, including handling for LLM-based signals and additional debugging output.

- Enhance wallet notification logic to support LLM signals with proper ETH/USDC conversions and fallbacks
- Add detailed debugging logs in model predictions when sending notifications
- Update fear & greed API caching duration to a fixed 12-hour period